### PR TITLE
`clear` and `completeStep` shouldn't be publicly visible

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -101,7 +101,7 @@ class _MyHomePageState extends State<MyHomePage> {
                         .button
                         .copyWith(color: Colors.white)),
                 onPressed: () =>
-                    FeatureDiscovery.markStepComplete(context, feature1),
+                    FeatureDiscovery.completeStep(context, feature1),
               ),
               FlatButton(
                 padding: const EdgeInsets.all(0),

--- a/lib/src/described_feature_overlay.dart
+++ b/lib/src/described_feature_overlay.dart
@@ -169,7 +169,7 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
               setState(() => state = _OverlayState.activating);
               break;
             case AnimationStatus.completed:
-              FeatureDiscovery.completeStep(context);
+              FeatureDiscovery._forceCompleteStep(context);
               break;
             default:
               break;
@@ -188,7 +188,7 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
               setState(() => state = _OverlayState.dismissing);
               break;
             case AnimationStatus.completed:
-              FeatureDiscovery.clear(context);
+              FeatureDiscovery._forceDismiss(context);
               break;
             default:
               break;
@@ -249,7 +249,7 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
           if (shouldOpen)
             show();
           else // Move on to the next step as this step should not be opened.
-            FeatureDiscovery.completeStep(context);
+            FeatureDiscovery._forceCompleteStep(context);
         });
       else
         show();

--- a/lib/src/feature_discovery.dart
+++ b/lib/src/feature_discovery.dart
@@ -22,30 +22,30 @@ class FeatureDiscovery extends StatefulWidget {
   /// This will schedule completion of the current discovery step and continue
   /// onto the step after the activation animation of the current overlay if successful.
   ///
-  /// If the [DescribedFeatureOverlay] that is associated with the current step is
-  /// not being displayed, this will fail. In that case, use [completeStep].
-  ///
+  // If the [DescribedFeatureOverlay] that is associated with the current step is
+  // not being displayed, this will fail. In that case, use [_forceCompleteStep].
+  //
   /// The [stepId] ensures that you are marking the correct feature for completion.
   /// If the provided [stepId] does not match the feature that is currently shown, i.e.
   /// the currently active step, nothing will happen.
-  static void markStepComplete(BuildContext context, String stepId) {
+  static void completeStep(BuildContext context, String stepId) {
     _FeatureDiscoveryState.of(context).markStepComplete(stepId);
   }
 
-  /// It is recommend to use [markStepComplete] whenever you can as it shows an animation for context.
+  /// It is recommend to use [completeStep] whenever you can as it shows an animation for context.
   ///
   /// This will force complete the current step and move on to the next step without any animations.
-  static void completeStep(BuildContext context) {
+  static void _forceCompleteStep(BuildContext context) {
     _FeatureDiscoveryState.of(context).completeStep();
   }
 
   /// This will schedule dismissal of the current discovery step and with that
   /// of the current feature discovery. The dismissal animation will play if successful.
   /// If you want to complete the step instead and with that continue the feature discovery,
-  /// you will need to call [markStepComplete] instead.
+  /// you will need to call [completeStep] instead.
   ///
   /// If the [DescribedFeatureOverlay] that is associated with the current step is
-  /// not being displayed, this will fail. In that case, use [clear].
+  /// not being displayed, this will fail. In that case, use [_forceDismiss].
   static void dismiss(BuildContext context) {
     _FeatureDiscoveryState.of(context).dismiss();
   }
@@ -53,7 +53,7 @@ class FeatureDiscovery extends StatefulWidget {
   /// This will force clear the current feature discovery and cancel the whole
   /// process without an animation.
   /// If you want to dismiss the current step regularly, call [dismiss].
-  static void clear(BuildContext context) {
+  static void _forceDismiss(BuildContext context) {
     _FeatureDiscoveryState.of(context).clear();
   }
 


### PR DESCRIPTION
I renamed the function `clear` to `forceDismiss` and `complete` to `forceComplete` to better understand what they do. 
Also, I made them private because I think they're not clearly distinct from the two others that have a similar behavior. 
I think we implemented them only for internal use. It's unlikely that users will need them. 