### PR TITLE
wrapBackground in example

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -378,7 +378,7 @@ class _ContentState extends State<Content> {
                     for (int n = feature6ItemCount; n > 0; n--)
                       const Text('Testing OverflowMode.wrapBackground'),
                   ]),
-                  overflowMode: OverflowMode.clipContent,
+                  overflowMode: OverflowMode.wrapBackground,
                   child: EnsureVisible(
                     key: ensureKey2,
                     child: const Text(


### PR DESCRIPTION
The `Text` widgets do not make much sense without `wrapBackground`. Alternatively, you could change the whole feature overlay.