### PR TITLE
Version 0.7.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,12 +1,6 @@
 name: Flutter Unit Testing, Format & Analysis
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - '*'
+on: [push, pull_request]
 
 jobs:
   test:
@@ -41,6 +35,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: axel-op/dart_package_analyzer@stable
+      - uses: axel-op/dart-package-analyzer@stable
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ pubspec.lock
 **/android/**/GeneratedPluginRegistrant.java
 **/example/android/app/.*
 example/android/.project
+example/android/.settings
 
 # iOS/XCode related
 **/ios/**/*.mode1v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 * **Deprecations:**
   * `activeFeatureId` has been deprecated and replaced by `currentFeatureIdOf`, to emphasize that this is a getter.
   * `dismiss` has been deprecated and replaced by `dismissAll` to be clear on the fact that no next step will be shown.
+* Non breaking:
+  * Incorrect documentation of some static methods in `FeatureDiscovery` has been edited.
+  * Error messages have been improved : the error thrown when the widget tree isn't wrapped in a `FeatureDiscovery` widget is clearer.
 
 ## 0.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,16 @@
-# Changelog
-
 ## 0.7.0
 
-* **Breaking changes:**
-  * Deprecated static methods of `FeatureDiscovery` class have been removed.
-  * Deprecated paramaters in the constructor of `EnsureVisible` have been removed.
-* **Deprecations:**
-  * `activeFeatureId` has been deprecated and replaced by `currentFeatureIdOf`, to emphasize that this is a getter.
-  * `dismiss` has been deprecated and replaced by `dismissAll` to be clear on the fact that no next step will be shown.
-* Non breaking:
-  * Incorrect documentation of some static methods in `FeatureDiscovery` has been edited.
-  * Error messages have been improved : the error thrown when the widget tree isn't wrapped in a `FeatureDiscovery` widget is clearer.
+* **Breaking change:** removed deprecated static methods in `FeatureDiscovery`.
+* **Breaking change:** removed deprecated parameters in the `EnsureVisible` constructor.
+* **Breaking change:** overlays will always be dismissed when calling `FeatureDiscovery.dismissAll`.
+* *Deprecated* `activeFeatureId`; replaced by `currentFeatureIdOf` to emphasize that this is a getter.
+* *Deprecated* `FeatureDiscovery.dismiss`; replaced by `dismissAll` to indicate that no next step
+  will be shown.
+* Added `assert` to require at least one step to be passed to `FeatureDiscovery.discoverFeatures`.
+* Incorrect documentation of some static methods in `FeatureDiscovery` has been updated.
+* Error messages have been improved : the error thrown when the widget tree isn't wrapped in
+  a `FeatureDiscovery` widget is clearer.
+* Incorrect behavior when `onDismiss` returned `Future<false>` has been fixed.
 
 ## 0.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Changelog
+
+## 0.7.0
+
+* **Breaking changes:**
+  * Deprecated static methods of `FeatureDiscovery` class have been removed.
+  * Deprecated paramaters in the constructor of `EnsureVisible` have been removed.
+
 ## 0.6.1
 
 * Update version constraint to `^4.0.1` for `provider` dependency.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * **Breaking changes:**
   * Deprecated static methods of `FeatureDiscovery` class have been removed.
   * Deprecated paramaters in the constructor of `EnsureVisible` have been removed.
+* **Deprecations:**
+  * `activeFeatureId` has been deprecated and replaced by `currentFeatureIdOf`, to emphasize that this is a getter.
+  * `dismiss` has been deprecated and replaced by `dismissAll` to be clear on the fact that no next step will be shown.
 
 ## 0.6.1
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -25,6 +25,7 @@ class MyApp extends StatelessWidget {
         theme: ThemeData(
           primarySwatch: Colors.blue,
         ),
+        // Required: this widget works like an inherited widget.
         home: const FeatureDiscovery(
           child: MyHomePage(title: 'Flutter Feature Discovery'),
         ),
@@ -164,7 +165,7 @@ class _MyHomePageState extends State<MyHomePage> {
                           .textTheme
                           .button
                           .copyWith(color: Colors.white)),
-                  onPressed: () => FeatureDiscovery.dismiss(context),
+                  onPressed: () => FeatureDiscovery.dismissAll(context),
                 ),
               ],
             ),

--- a/lib/src/foundation/bloc.dart
+++ b/lib/src/foundation/bloc.dart
@@ -20,10 +20,13 @@ class Bloc {
   /// This is used to retrieve the [Bloc] in [FeatureDiscovery] and [DescribedOverlayState].
   /// It can be public here because [Bloc] is not exposed when importing `feature_discovery`.
   static Bloc of(BuildContext context) {
-    final Bloc bloc = Provider.of<Bloc>(context, listen: false);
-    assert(bloc != null,
-        "Don't forget to wrap your widget tree in a [FeatureDiscovery] widget.");
-    return bloc;
+    try {
+      return Provider.of<Bloc>(context, listen: false);
+    } on ProviderNotFoundException {
+      throw BlocNotFoundError(
+          'Could not find a FeatureDiscovery widget above this context.'
+          '\nFeatureDiscovery works like an inherited widget. You must wrap your widget tree in it.');
+    }
   }
 
   Bloc._();
@@ -128,4 +131,9 @@ enum EventType {
   open,
   complete,
   dismiss,
+}
+
+class BlocNotFoundError extends Error {
+  final String message;
+  BlocNotFoundError(this.message) : super();
 }

--- a/lib/src/foundation/bloc.dart
+++ b/lib/src/foundation/bloc.dart
@@ -81,8 +81,9 @@ class Bloc {
     _eventsController.close();
   }
 
-  void discoverFeatures({Iterable<String> steps}) {
-    assert(steps != null);
+  void discoverFeatures(Iterable<String> steps) {
+    assert(steps != null && steps.isNotEmpty,
+        'You need to pass at least one step to [FeatureDiscovery.discoverFeatures].');
     _steps = steps;
     _activeStepIndex = 0;
     _activeOverlays = 0;

--- a/lib/src/foundation/feature_discovery.dart
+++ b/lib/src/foundation/feature_discovery.dart
@@ -47,19 +47,6 @@ class FeatureDiscovery extends StatelessWidget {
   static String activeFeatureId(BuildContext context) =>
       Bloc.of(context).activeFeatureId;
 
-  /// Deprecated methods, kept for retrocompatibility.
-  @Deprecated('Use [dismiss] instead')
-  static void clear(BuildContext context) => dismiss(context);
-
-  @Deprecated('Use [completeCurrentStep] instead')
-  static void completeStep(BuildContext context) =>
-      completeCurrentStep(context);
-
-  @Deprecated(
-      'Use [completeCurrentStep] instead ; [stepId] argument will not be used')
-  static void markStepComplete(BuildContext context, String stepId) =>
-      completeCurrentStep(context);
-
   final Widget child;
 
   const FeatureDiscovery({Key key, this.child}) : super(key: key);

--- a/lib/src/foundation/feature_discovery.dart
+++ b/lib/src/foundation/feature_discovery.dart
@@ -35,17 +35,24 @@ class FeatureDiscovery extends StatelessWidget {
   /// of the current feature discovery. The dismissal animation will play if successful.
   /// If you want to complete the step and continue the feature discovery,
   /// call [completeCurrentStep] instead.
-  static void dismiss(BuildContext context) => Bloc.of(context).dismiss();
+  static void dismissAll(BuildContext context) => Bloc.of(context).dismiss();
 
-  /// This return the feature id of the current feature discovery step, i.e.
+  @Deprecated("Use [dismissAll] instead.")
+  static void dismiss(BuildContext context) => dismissAll(context);
+
+  /// This returns the feature id of the current feature discovery step, i.e.
   /// of the [DescribedFeatureOverlay] that is currently supposed to be shown, or `null`.
   ///
   /// Note that this will also return the feature id of the current step of the steps
   /// you passed to [discoverFeature] even when there is no [DescribedFeatureOverlay]
   /// in the tree to display the overlay.
   /// This means that you cannot use this to check if a feature overlay is being displayed.
-  static String activeFeatureId(BuildContext context) =>
+  static String currentFeatureIdOf(BuildContext context) =>
       Bloc.of(context).activeFeatureId;
+
+  @Deprecated("Use [currentFeatureIdOf] instead.")
+  static String activeFeatureId(BuildContext context) =>
+      currentFeatureIdOf(context);
 
   final Widget child;
 

--- a/lib/src/foundation/feature_discovery.dart
+++ b/lib/src/foundation/feature_discovery.dart
@@ -16,26 +16,31 @@ enum ContentLocation {
 }
 
 class FeatureDiscovery extends StatelessWidget {
+  static Bloc _blocOf(BuildContext context) {
+    try {
+      return Bloc.of(context);
+    } on BlocNotFoundError catch (e) {
+      throw FlutterError(e.message +
+          '\nEnsure that it also wraps the context of the ${context.widget.runtimeType} widget from which you have called a static method in FeatureDiscovery.');
+    }
+  }
+
   /// Steps are the featureIds of the overlays.
   /// Though they can be placed in any [Iterable], it is recommended to pass them as a [Set]
   /// because this ensures that every step is only shown once.
   static void discoverFeatures(BuildContext context, Iterable<String> steps) =>
-      Bloc.of(context).discoverFeatures(steps: steps.toList());
+      _blocOf(context).discoverFeatures(steps: steps.toList());
 
   /// This will schedule completion of the current discovery step and continue
   /// onto the step after the completion animation of the current overlay if successful.
-  ///
-  /// The [stepId] ensures that you are marking the correct feature for completion.
-  /// If the provided [stepId] does not match the feature that is currently shown, i.e.
-  /// the currently active step, nothing will happen.
   static void completeCurrentStep(BuildContext context) =>
-      Bloc.of(context).completeStep();
+      _blocOf(context).completeStep();
 
   /// This will schedule dismissal of the current discovery step and with that
   /// of the current feature discovery. The dismissal animation will play if successful.
   /// If you want to complete the step and continue the feature discovery,
   /// call [completeCurrentStep] instead.
-  static void dismissAll(BuildContext context) => Bloc.of(context).dismiss();
+  static void dismissAll(BuildContext context) => _blocOf(context).dismiss();
 
   @Deprecated("Use [dismissAll] instead.")
   static void dismiss(BuildContext context) => dismissAll(context);
@@ -44,11 +49,11 @@ class FeatureDiscovery extends StatelessWidget {
   /// of the [DescribedFeatureOverlay] that is currently supposed to be shown, or `null`.
   ///
   /// Note that this will also return the feature id of the current step of the steps
-  /// you passed to [discoverFeature] even when there is no [DescribedFeatureOverlay]
+  /// you passed to [discoverFeatures] even when there is no [DescribedFeatureOverlay]
   /// in the tree to display the overlay.
   /// This means that you cannot use this to check if a feature overlay is being displayed.
   static String currentFeatureIdOf(BuildContext context) =>
-      Bloc.of(context).activeFeatureId;
+      _blocOf(context).activeFeatureId;
 
   @Deprecated("Use [currentFeatureIdOf] instead.")
   static String activeFeatureId(BuildContext context) =>

--- a/lib/src/foundation/feature_discovery.dart
+++ b/lib/src/foundation/feature_discovery.dart
@@ -29,20 +29,21 @@ class FeatureDiscovery extends StatelessWidget {
   /// Though they can be placed in any [Iterable], it is recommended to pass them as a [Set]
   /// because this ensures that every step is only shown once.
   static void discoverFeatures(BuildContext context, Iterable<String> steps) =>
-      _blocOf(context).discoverFeatures(steps: steps.toList());
+      _blocOf(context).discoverFeatures(steps.toList());
 
   /// This will schedule completion of the current discovery step and continue
   /// onto the step after the completion animation of the current overlay if successful.
   static void completeCurrentStep(BuildContext context) =>
       _blocOf(context).completeStep();
 
-  /// This will schedule dismissal of the current discovery step and with that
-  /// of the current feature discovery. The dismissal animation will play if successful.
-  /// If you want to complete the step and continue the feature discovery,
+  /// A method to dismiss all steps.
+  ///
+  /// The `onDimiss` parameter will be ignored for every active overlay.
+  /// If you want to complete the current step and continue the feature discovery,
   /// call [completeCurrentStep] instead.
   static void dismissAll(BuildContext context) => _blocOf(context).dismiss();
 
-  @Deprecated("Use [dismissAll] instead.")
+  @Deprecated('Use [dismissAll] instead.')
   static void dismiss(BuildContext context) => dismissAll(context);
 
   /// This returns the feature id of the current feature discovery step, i.e.
@@ -55,7 +56,7 @@ class FeatureDiscovery extends StatelessWidget {
   static String currentFeatureIdOf(BuildContext context) =>
       _blocOf(context).activeFeatureId;
 
-  @Deprecated("Use [currentFeatureIdOf] instead.")
+  @Deprecated('Use [currentFeatureIdOf] instead.')
   static String activeFeatureId(BuildContext context) =>
       currentFeatureIdOf(context);
 

--- a/lib/src/rendering/custom_layout.dart
+++ b/lib/src/rendering/custom_layout.dart
@@ -85,12 +85,12 @@ class BackgroundContentLayoutDelegate extends MultiChildLayoutDelegate {
       final distanceToOuterPulse = anchorPoint.distanceTo(backgroundPoint) + 75;
 
       // Calculate distance to the furthest point of the content.
-      final Rect contentArea = Rect.fromLTWH(contentPoint.x, contentPoint.y,
+      final contentArea = Rect.fromLTWH(contentPoint.x, contentPoint.y,
           contentSize.width, contentSize.height);
       // This is equal to finding the max out of the distances to the corners of the Rect.
       // It is just the more Math-esque approach.
       // See the commented out code below for an intuitive approach.
-      final double contentDx = max((contentArea.left - backgroundPoint.x).abs(),
+      final contentDx = max((contentArea.left - backgroundPoint.x).abs(),
               (contentArea.right - backgroundPoint.x)),
           contentDy = max((contentArea.top - backgroundPoint.y).abs(),
               (contentArea.bottom - backgroundPoint.y).abs());

--- a/lib/src/widgets/content.dart
+++ b/lib/src/widgets/content.dart
@@ -43,15 +43,13 @@ class Content extends StatelessWidget {
       case FeatureOverlayState.closed:
         return 0;
       case FeatureOverlayState.opening:
-        final double adjustedPercent =
-            const Interval(0.6, 1, curve: Curves.easeOut)
-                .transform(transitionProgress);
+        final adjustedPercent = const Interval(0.6, 1, curve: Curves.easeOut)
+            .transform(transitionProgress);
         return adjustedPercent;
       case FeatureOverlayState.completing:
       case FeatureOverlayState.dismissing:
-        final double adjustedPercent =
-            const Interval(0, 0.4, curve: Curves.easeOut)
-                .transform(transitionProgress);
+        final adjustedPercent = const Interval(0, 0.4, curve: Curves.easeOut)
+            .transform(transitionProgress);
         return 1 - adjustedPercent;
       case FeatureOverlayState.opened:
         return 1;
@@ -79,7 +77,7 @@ class Content extends StatelessWidget {
                   DefaultTextStyle(
                     style: Theme.of(context)
                         .textTheme
-                        .title
+                        .title // TODO(creativecreatorormaybenot): Update to headline6 when Flutter stable deprecates title.
                         .copyWith(color: textColor),
                     child: title,
                   ),
@@ -89,7 +87,7 @@ class Content extends StatelessWidget {
                   DefaultTextStyle(
                     style: Theme.of(context)
                         .textTheme
-                        .body1
+                        .body1 // TODO(creativecreatorormaybenot): Update to bodyText2 when Flutter stable deprecates body1.
                         .copyWith(color: textColor.withOpacity(0.9)),
                     child: description,
                   )

--- a/lib/src/widgets/ensure_visible.dart
+++ b/lib/src/widgets/ensure_visible.dart
@@ -5,27 +5,8 @@ class EnsureVisible extends StatefulWidget {
   /// The child widget that we are wrapping
   final Widget child;
 
-  /// The curve we will use to scroll ourselves into view.
-  ///
-  /// Defaults to Curves.ease.
-  final Curve curve;
-
-  /// The duration we will use to scroll ourselves into view.
-  ///
-  /// Defaults to 100 milliseconds.
-  final Duration duration;
-
-  const EnsureVisible({
-    Key key,
-    @required
-        this.child,
-    @Deprecated('If you use this, the curve parameter in EnsureVisibleState.ensureVisible will be ignored. You should use that parameter instead.')
-        // ignore: deprecated_member_use_from_same_package
-        this.curve,
-    @Deprecated('If you use this, the duration parameter in EnsureVisibleState.ensureVisible will be ignored. You should use that parameter instead.')
-        // ignore: deprecated_member_use_from_same_package
-        this.duration,
-  })  : assert(child != null),
+  const EnsureVisible({Key key, @required this.child})
+      : assert(child != null),
         super(key: key);
 
   @override
@@ -94,8 +75,8 @@ class EnsureVisibleState extends State<EnsureVisible> {
     return await position.ensureVisible(
       renderObject,
       alignment: alignment,
-      duration: widget.duration ?? duration,
-      curve: widget.curve ?? curve,
+      duration: duration,
+      curve: curve,
     );
   }
 

--- a/lib/src/widgets/overlay.dart
+++ b/lib/src/widgets/overlay.dart
@@ -150,7 +150,7 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
   AnimationController _dismissController;
 
   /// The local reference to the [Bloc] is needed because it is used in [dispose].
-  Bloc bloc;
+  Bloc _bloc;
 
   Stream<EventType> _eventsStream;
   StreamSubscription<EventType> _eventsSubscription;
@@ -192,15 +192,15 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
     _screenSize = MediaQuery.of(context).size;
 
     try {
-      bloc = Bloc.of(context);
+      _bloc = Bloc.of(context);
 
-      final Stream<EventType> newEventsStream = bloc.eventsOut;
+      final Stream<EventType> newEventsStream = _bloc.eventsOut;
       if (_eventsStream != newEventsStream) _setStream(newEventsStream);
 
       // If this widget was not in the tree when the feature discovery was started,
       // we need to open it immediately because the streams will not receive
       // any further events that could open the overlay.
-      if (bloc.activeFeatureId == widget.featureId &&
+      if (_bloc.activeFeatureId == widget.featureId &&
           _state == FeatureOverlayState.closed) _open();
     } on BlocNotFoundError catch (e) {
       throw FlutterError(e.message +
@@ -233,9 +233,9 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
         _state != FeatureOverlayState.completing) {
       // If the _state is anything else, this overlay has to be showing,
       // otherwise something is wrong.
-      assert(bloc.activeFeatureId == widget.featureId);
+      assert(_bloc.activeFeatureId == widget.featureId);
 
-      bloc.activeOverlays--;
+      _bloc.activeOverlays--;
     }
     super.dispose();
   }
@@ -249,7 +249,7 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
       switch (event) {
         case EventType.open:
           // Only try opening when the active feature id matches the id of this widget.
-          if (bloc.activeFeatureId != widget.featureId) return;
+          if (_bloc.activeFeatureId != widget.featureId) return;
           await _open();
           return;
         case EventType.complete:
@@ -299,9 +299,9 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
   }
 
   Future<void> _open() async {
-    if (!widget.allowShowingDuplicate && bloc.activeOverlays > 0) return;
+    if (!widget.allowShowingDuplicate && _bloc.activeOverlays > 0) return;
 
-    bloc.activeOverlays++;
+    _bloc.activeOverlays++;
 
     if (widget.onOpen != null) {
       final bool shouldOpen = await widget.onOpen();
@@ -315,7 +315,7 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
 
     // The activeStep might have changed by now because onOpen is asynchronous.
     // For example, the step might have been completed programmatically.
-    if (bloc.activeFeatureId != widget.featureId) return;
+    if (_bloc.activeFeatureId != widget.featureId) return;
 
     // setState will be called in the animation listener.
     _state = FeatureOverlayState.opening;
@@ -567,9 +567,9 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
     return Stack(
       children: <Widget>[
         GestureDetector(
-          onTap: bloc.dismiss,
+          onTap: _bloc.dismiss,
           // According to the spec, the user should be able to dismiss by swiping.
-          onPanUpdate: (DragUpdateDetails _) => bloc.dismiss(),
+          onPanUpdate: (DragUpdateDetails _) => _bloc.dismiss(),
           child: Container(
             width: double.infinity,
             height: double.infinity,

--- a/lib/src/widgets/overlay.dart
+++ b/lib/src/widgets/overlay.dart
@@ -191,16 +191,21 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
   void didChangeDependencies() {
     _screenSize = MediaQuery.of(context).size;
 
-    bloc = Bloc.of(context);
+    try {
+      bloc = Bloc.of(context);
 
-    final Stream<EventType> newEventsStream = bloc.eventsOut;
-    if (_eventsStream != newEventsStream) _setStream(newEventsStream);
+      final Stream<EventType> newEventsStream = bloc.eventsOut;
+      if (_eventsStream != newEventsStream) _setStream(newEventsStream);
 
-    // If this widget was not in the tree when the feature discovery was started,
-    // we need to open it immediately because the streams will not receive
-    // any further events that could open the overlay.
-    if (bloc.activeFeatureId == widget.featureId &&
-        _state == FeatureOverlayState.closed) _open();
+      // If this widget was not in the tree when the feature discovery was started,
+      // we need to open it immediately because the streams will not receive
+      // any further events that could open the overlay.
+      if (bloc.activeFeatureId == widget.featureId &&
+          _state == FeatureOverlayState.closed) _open();
+    } on BlocNotFoundError catch (e) {
+      throw FlutterError(e.message +
+          '\nEnsure that all the DescribedFeatureOverlay widgets are below it.');
+    }
 
     super.didChangeDependencies();
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,14 +11,22 @@ authors:
 homepage: https://github.com/ayalma/feature_discovery
 
 environment:
-  sdk: '>=2.2.2 <3.0.0' # This should never be higher than the Flutter stable constraints.
+  # This should match the Flutter stable SDK constraint.
+  # See https://github.com/flutter/flutter/blob/stable/packages/flutter/pubspec.yaml.
+  sdk: '>=2.2.2 <3.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
-  provider: ^4.0.2
+
+  provider: ^4.0.4
 
 dev_dependencies:
-  pedantic: any
   flutter_test:
     sdk: flutter
+
+  pedantic: 1.9.0
+
+dependency_overrides:
+  # TODO(creativecreatorormaybenot): Remove when Pedantic is updated in flutter_test.
+  pedantic: 1.9.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A Flutter package that implements Material Design Feature discovery
   to show a description of specific features to new users.
   See https://tinyurl.com/FeatureDiscovery
-version: 0.6.1
+version: 0.7.0
 authors:
   - ayalma <alimohammadi7117@gmail.com>
   - creativecreatorormaybenot <19204050+creativecreatorormaybenot@users.noreply.github.com>
@@ -16,7 +16,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  provider: ^4.0.1
+  provider: ^4.0.2
 
 dev_dependencies:
   pedantic: any

--- a/test/feature_discovery_test.dart
+++ b/test/feature_discovery_test.dart
@@ -45,7 +45,7 @@ void main() {
       expect(find.text(texts[1]), findsNothing);
       expect(find.text(texts[2]), findsOneWidget);
       // Dismiss all
-      FeatureDiscovery.dismiss(context);
+      FeatureDiscovery.dismissAll(context);
       await tester.pumpAndSettle();
       // No overlay should remain
       texts.forEach((t) => expect(find.text(t), findsNothing));

--- a/test/feature_discovery_test.dart
+++ b/test/feature_discovery_test.dart
@@ -20,13 +20,13 @@ void main() {
       'featureIdC',
       'featureIdD',
     ];
-    final List<String> texts = textsToMatch(steps);
+    final texts = textsToMatch(steps);
     testWidgets('Displaying two steps and dismissing before the third',
         (WidgetTester tester) async {
       await tester.pumpWidget(const TestWidget(featureIds: steps));
-      final Finder finder = find.byType(TestIcon);
+      final finder = find.byType(TestIcon);
       expect(finder, findsNWidgets(steps.length));
-      final BuildContext context = tester.firstState(finder).context;
+      final context = tester.firstState(finder).context;
       // Should be no overlays before calling discoverFeatures
       texts.forEach((t) => expect(find.text(t), findsNothing));
       FeatureDiscovery.discoverFeatures(context, steps);
@@ -61,9 +61,9 @@ void main() {
       await tester.pumpWidget(TestWidget(
           // Only one overlay will be placed in the tree
           featureIds: featureIds.sublist(1, 2)));
-      final Finder finder = find.byType(TestIcon);
+      final finder = find.byType(TestIcon);
       expect(finder, findsOneWidget);
-      final BuildContext context = tester.firstState(finder).context;
+      final context = tester.firstState(finder).context;
       FeatureDiscovery.discoverFeatures(context, featureIds);
       await tester.pumpAndSettle();
       // First overlay should NOT appear
@@ -80,7 +80,7 @@ void main() {
   });
 
   group('Duplicate feature ids', () {
-    for (final bool allowShowingDuplicate in <bool>[true, false]) {
+    for (final allowShowingDuplicate in <bool>[true, false]) {
       const featureIds = <String>[
         'featureIdA',
         'featureIdB',
@@ -102,9 +102,9 @@ void main() {
           allowShowingDuplicate: allowShowingDuplicate,
         ));
 
-        final Finder finder = find.byType(TestIcon);
+        final finder = find.byType(TestIcon);
         expect(finder, findsNWidgets(featureIds.length));
-        final BuildContext context = tester.firstState(finder).context;
+        final context = tester.firstState(finder).context;
         texts.forEach((t) => expect(find.text(t), findsNothing));
 
         FeatureDiscovery.discoverFeatures(context, steps);
@@ -131,9 +131,9 @@ void main() {
 
     testWidgets('Show other overlay after duplicate has been removed',
         (WidgetTester tester) async {
-      const String featureId = 'feature';
-      const IconData featureIcon = Icons.content_copy;
-      const String staticFeatureTitle = 'Static',
+      const featureId = 'feature';
+      const featureIcon = Icons.content_copy;
+      const staticFeatureTitle = 'Static',
           disposableFeatureTitle = 'Disposable';
 
       await tester.pumpWidget(const WidgetWithDisposableFeature(
@@ -143,14 +143,14 @@ void main() {
         disposableFeatureTitle: disposableFeatureTitle,
       ));
 
-      final Finder stateFinder = find.byType(WidgetWithDisposableFeature);
+      final stateFinder = find.byType(WidgetWithDisposableFeature);
       expect(stateFinder, findsOneWidget);
-      final WidgetWithDisposableFeatureState state =
-          tester.firstState(stateFinder);
+      final state =
+          tester.firstState(stateFinder) as WidgetWithDisposableFeatureState;
 
       // Need some widget to return a context that has the Bloc widget as an ancestor.
-      final Finder overlayFinder = find.byType(DescribedFeatureOverlay);
-      final BuildContext context = tester.firstState(overlayFinder).context;
+      final overlayFinder = find.byType(DescribedFeatureOverlay);
+      final context = tester.firstState(overlayFinder).context;
 
       // Feature titles should only be visible once feature discovery has been started.
       expect(find.text(staticFeatureTitle), findsNothing);
@@ -179,22 +179,22 @@ void main() {
   });
 
   group('OverflowMode', () {
-    const IconData icon = Icons.error;
-    const String featureId = 'feature';
+    const icon = Icons.error;
+    const featureId = 'feature';
 
     // Declares what OverflowMode's should allow the button to be tapped.
-    const Map<OverflowMode, bool> modes = <OverflowMode, bool>{
+    const modes = <OverflowMode, bool>{
       OverflowMode.ignore: false,
       OverflowMode.extendBackground: false,
       OverflowMode.wrapBackground: false,
       OverflowMode.clipContent: true,
     };
 
-    for (final MapEntry<OverflowMode, bool> modeEntry in modes.entries) {
+    for (final modeEntry in modes.entries) {
       testWidgets(modeEntry.key.toString(), (WidgetTester tester) async {
         BuildContext context;
 
-        bool triggered = false;
+        var triggered = false;
 
         // The surface size is set to ensure that the minimum overlay background size
         // does not cover the button, but the content does.

--- a/test/widgets.dart
+++ b/test/widgets.dart
@@ -72,7 +72,7 @@ class TestIcon extends StatefulWidget {
 class TestIconState extends State<TestIcon> {
   @override
   Widget build(BuildContext context) {
-    const Icon icon = Icon(Icons.more_horiz);
+    const icon = Icon(Icons.more_horiz);
     return DescribedFeatureOverlay(
       featureId: widget.featureId,
       // It is mandatory to disable the pulsing animation


### PR DESCRIPTION
* **Breaking changes:** 
  * Deprecated static methods of `FeatureDiscovery` class have been removed. 
  * Deprecated paramaters in the constructor of `EnsureVisible` have been removed. 
* Non breaking: 
   * `activeFeatureId` has been deprecated and replaced by `getCurrentFeatureId`, to emphasize that this is a getter. 
  * `dismiss` has been deprecated and replaced by `dismissAll` to be clear on the fact that no next step will be shown. 
  * Incorrect documentation of some static methods in `FeatureDiscovery` has been edited. 
  * Error messages have been improved : the error thrown when the widget tree isn't wrapped in a `FeatureDiscovery` widget is clearer.
  * Fixes a bug when `onDismiss` returns a `Future<false>` (see https://github.com/axel-op/feature_discovery/pull/44).

This PR will fix #14.