### PR TITLE
#55 fixed position param to work with BottomNavigationBar

### DIFF
--- a/lib/src/widgets/overlay.dart
+++ b/lib/src/widgets/overlay.dart
@@ -454,7 +454,7 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
   }
 
   bool _isCloseToTopOrBottom(Offset position) =>
-      position.dy <= 88.0 || (_screenSize.height - position.dy) <= 88.0;
+      position.dy <= 100.0 || (_screenSize.height - position.dy) <= 100.0;
 
   bool _isOnTopHalfOfScreen(Offset position) =>
       position.dy < (_screenSize.height / 2.0);


### PR DESCRIPTION
https://github.com/ayalma/feature_discovery/issues/55 text on overlay was not visible while using a BottomNavigationBar