### PR TITLE
Migrate to null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 0.14.0
+* Migrated to null safety
+
 ## 0.13.0+1
 * Clear Preferences issue fixed
 ## 0.13.0

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -103,30 +103,32 @@ class _MyHomePageState extends State<MyHomePage> {
               children: <Widget>[
                 const Text(
                     'Also, notice how the pulsing animation is not playing because it is deactivated for this feature.'),
-                FlatButton(
-                    child: Text('Toggle enablePulsingAnimation',
-                        style: Theme.of(context)
-                            .textTheme
-                            .button
-                            .copyWith(color: Colors.white)),
-                    onPressed: () => setState(() {
-                          feature1EnablePulsingAnimation =
-                              !feature1EnablePulsingAnimation;
-                        })),
+                TextButton(
+                  onPressed: () => setState(() {
+                    feature1EnablePulsingAnimation =
+                        !feature1EnablePulsingAnimation;
+                  }),
+                  child: Text('Toggle enablePulsingAnimation',
+                      style: Theme.of(context)
+                          .textTheme
+                          .button
+                          .copyWith(color: Colors.white)),
+                ),
                 const Text(
                     'Ignore the items below or tap the button to toggle between OverflowMode.clip and OverflowMode.doNothing!'),
-                FlatButton(
-                    child: Text('Toggle overflowMode',
-                        style: Theme.of(context)
-                            .textTheme
-                            .button
-                            .copyWith(color: Colors.white)),
-                    onPressed: () => setState(() {
-                          feature1OverflowMode =
-                              feature1OverflowMode == OverflowMode.clipContent
-                                  ? OverflowMode.ignore
-                                  : OverflowMode.clipContent;
-                        })),
+                TextButton(
+                  onPressed: () => setState(() {
+                    feature1OverflowMode =
+                        feature1OverflowMode == OverflowMode.clipContent
+                            ? OverflowMode.ignore
+                            : OverflowMode.clipContent;
+                  }),
+                  child: Text('Toggle overflowMode',
+                      style: Theme.of(context)
+                          .textTheme
+                          .button
+                          .copyWith(color: Colors.white)),
+                ),
                 for (int n = 42; n > 0; n--)
                   const Text('Testing clipping (ignore or toggle)',
                       style: TextStyle(backgroundColor: Colors.black)),
@@ -149,24 +151,26 @@ class _MyHomePageState extends State<MyHomePage> {
               children: <Widget>[
                 const Text(
                     'Tap the magnifying glass to quickly scan your compounds'),
-                FlatButton(
-                  padding: const EdgeInsets.all(0),
-                  child: Text('Understood',
-                      style: Theme.of(context)
-                          .textTheme
-                          .button
-                          .copyWith(color: Colors.white)),
+                TextButton(
                   onPressed: () async =>
                       FeatureDiscovery.completeCurrentStep(context),
+                  child: Text(
+                    'Understood',
+                    style: Theme.of(context)
+                        .textTheme
+                        .button
+                        .copyWith(color: Colors.white),
+                  ),
                 ),
-                FlatButton(
-                  padding: const EdgeInsets.all(0),
-                  child: Text('Dismiss',
-                      style: Theme.of(context)
-                          .textTheme
-                          .button
-                          .copyWith(color: Colors.white)),
+                TextButton(
                   onPressed: () => FeatureDiscovery.dismissAll(context),
+                  child: Text(
+                    'Dismiss',
+                    style: Theme.of(context)
+                        .textTheme
+                        .button
+                        .copyWith(color: Colors.white),
+                  ),
                 ),
               ],
             ),
@@ -190,15 +194,16 @@ class _MyHomePageState extends State<MyHomePage> {
           description: Column(children: <Widget>[
             const Text(
                 'This is overly long to test OverflowMode.extendBackground. The green circle should be large enough to cover all of the text.'),
-            FlatButton(
-                child: Text('Add another item',
-                    style: Theme.of(context)
-                        .textTheme
-                        .button
-                        .copyWith(color: Colors.white)),
-                onPressed: () => setState(() {
-                      feature3ItemCount++;
-                    })),
+            TextButton(
+              onPressed: () => setState(() {
+                feature3ItemCount++;
+              }),
+              child: Text('Add another item',
+                  style: Theme.of(context)
+                      .textTheme
+                      .button
+                      .copyWith(color: Colors.white)),
+            ),
             for (int n = feature3ItemCount; n > 0; n--)
               const Text('Testing OverflowMode.extendBackground'),
           ]),
@@ -323,8 +328,7 @@ class _ContentState extends State<Content> {
                   contentLocation: ContentLocation.below,
                   child: EnsureVisible(
                     key: ensureKey,
-                    child: RaisedButton(
-                      child: const Text('Start Feature Discovery'),
+                    child: ElevatedButton(
                       onPressed: () {
                         FeatureDiscovery.discoverFeatures(
                           context,
@@ -338,6 +342,7 @@ class _ContentState extends State<Content> {
                           },
                         );
                       },
+                      child: const Text('Start Feature Discovery'),
                     ),
                   ),
                 ),
@@ -368,16 +373,16 @@ class _ContentState extends State<Content> {
                   description: Column(children: <Widget>[
                     const Text(
                         'You can test OverflowMode.wrapBackground here.'),
-                    FlatButton(
-                        padding: const EdgeInsets.all(0),
-                        child: Text('Add item',
-                            style: Theme.of(context)
-                                .textTheme
-                                .button
-                                .copyWith(color: Colors.white)),
-                        onPressed: () => setState(() {
-                              feature6ItemCount++;
-                            })),
+                    TextButton(
+                      onPressed: () => setState(() {
+                        feature6ItemCount++;
+                      }),
+                      child: Text('Add item',
+                          style: Theme.of(context)
+                              .textTheme
+                              .button
+                              .copyWith(color: Colors.white)),
+                    ),
                     for (int n = feature6ItemCount; n > 0; n--)
                       const Text('Testing OverflowMode.wrapBackground'),
                   ]),
@@ -416,10 +421,10 @@ class _ContentState extends State<Content> {
               child: FloatingActionButton(
                 backgroundColor: Colors.white,
                 foregroundColor: Colors.blue,
-                child: const Icon(Icons.drive_eta),
                 onPressed: () {
                   print('Floating action button tapped.');
                 },
+                child: const Icon(Icons.drive_eta),
               ),
             ),
           ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -34,9 +34,9 @@ class MyApp extends StatelessWidget {
 }
 
 class MyHomePage extends StatefulWidget {
-  const MyHomePage({Key key, this.title}) : super(key: key);
+  const MyHomePage({Key? key, this.title}) : super(key: key);
 
-  final String title;
+  final String? title;
 
   @override
   _MyHomePageState createState() => _MyHomePageState();
@@ -61,7 +61,7 @@ class _MyHomePageState extends State<MyHomePage> {
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(widget.title),
+        title: Text(widget.title!),
         bottom: PreferredSize(
           preferredSize: const Size.fromHeight(80),
           child: Column(
@@ -111,7 +111,7 @@ class _MyHomePageState extends State<MyHomePage> {
                   child: Text('Toggle enablePulsingAnimation',
                       style: Theme.of(context)
                           .textTheme
-                          .button
+                          .button!
                           .copyWith(color: Colors.white)),
                 ),
                 const Text(
@@ -126,7 +126,7 @@ class _MyHomePageState extends State<MyHomePage> {
                   child: Text('Toggle overflowMode',
                       style: Theme.of(context)
                           .textTheme
-                          .button
+                          .button!
                           .copyWith(color: Colors.white)),
                 ),
                 for (int n = 42; n > 0; n--)
@@ -158,7 +158,7 @@ class _MyHomePageState extends State<MyHomePage> {
                     'Understood',
                     style: Theme.of(context)
                         .textTheme
-                        .button
+                        .button!
                         .copyWith(color: Colors.white),
                   ),
                 ),
@@ -168,7 +168,7 @@ class _MyHomePageState extends State<MyHomePage> {
                     'Dismiss',
                     style: Theme.of(context)
                         .textTheme
-                        .button
+                        .button!
                         .copyWith(color: Colors.white),
                   ),
                 ),
@@ -201,7 +201,7 @@ class _MyHomePageState extends State<MyHomePage> {
               child: Text('Add another item',
                   style: Theme.of(context)
                       .textTheme
-                      .button
+                      .button!
                       .copyWith(color: Colors.white)),
             ),
             for (int n = feature3ItemCount; n > 0; n--)
@@ -219,22 +219,22 @@ class _MyHomePageState extends State<MyHomePage> {
 }
 
 class Content extends StatefulWidget {
-  const Content({Key key}) : super(key: key);
+  const Content({Key? key}) : super(key: key);
 
   @override
   _ContentState createState() => _ContentState();
 }
 
 class _ContentState extends State<Content> {
-  GlobalKey<EnsureVisibleState> ensureKey;
-  GlobalKey<EnsureVisibleState> ensureKey2;
+  GlobalKey<EnsureVisibleState>? ensureKey;
+  GlobalKey<EnsureVisibleState>? ensureKey2;
 
   @override
   void initState() {
     ensureKey = GlobalKey<EnsureVisibleState>();
     ensureKey2 = GlobalKey<EnsureVisibleState>();
 
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    WidgetsBinding.instance!.addPostFrameCallback((_) {
       FeatureDiscovery.discoverFeatures(
         context,
         const <String>{
@@ -314,8 +314,8 @@ class _ContentState extends State<Content> {
                     return true;
                   },
                   onOpen: () async {
-                    WidgetsBinding.instance.addPostFrameCallback((_) {
-                      ensureKey.currentState.ensureVisible(
+                    WidgetsBinding.instance!.addPostFrameCallback((_) {
+                      ensureKey!.currentState!.ensureVisible(
                         preciseAlignment: 0.5,
                         duration: const Duration(milliseconds: 400),
                       );
@@ -364,8 +364,8 @@ class _ContentState extends State<Content> {
                     return true;
                   },
                   onOpen: () async {
-                    WidgetsBinding.instance.addPostFrameCallback((_) {
-                      ensureKey2.currentState.ensureVisible(
+                    WidgetsBinding.instance!.addPostFrameCallback((_) {
+                      ensureKey2!.currentState!.ensureVisible(
                           duration: const Duration(milliseconds: 600));
                     });
                     return true;
@@ -380,7 +380,7 @@ class _ContentState extends State<Content> {
                       child: Text('Add item',
                           style: Theme.of(context)
                               .textTheme
-                              .button
+                              .button!
                               .copyWith(color: Colors.white)),
                     ),
                     for (int n = feature6ItemCount; n > 0; n--)

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -14,7 +14,7 @@ description: A new Flutter project.
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.2.2 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 publish_to: none
 

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -16,6 +16,8 @@ version: 1.0.0+1
 environment:
   sdk: ">=2.2.2 <3.0.0"
 
+publish_to: none
+
 dependencies:
   flutter:
     sdk: flutter

--- a/lib/src/foundation/feature_discovery.dart
+++ b/lib/src/foundation/feature_discovery.dart
@@ -67,7 +67,7 @@ class FeatureDiscovery extends StatelessWidget {
   /// you passed to [discoverFeatures] even when there is no [DescribedFeatureOverlay]
   /// in the tree to display the overlay.
   /// This means that you cannot use this to check if a feature overlay is being displayed.
-  static String currentFeatureIdOf(BuildContext context) =>
+  static String? currentFeatureIdOf(BuildContext context) =>
       _blocOf(context).activeFeatureId;
 
   final Widget child;
@@ -82,12 +82,10 @@ class FeatureDiscovery extends StatelessWidget {
   /// Instantiates a new [FeatureDiscovery] and stores completion of steps
   /// through the provided [persistenceProvider][PersistenceProvider].
   const FeatureDiscovery.withProvider({
-    @required this.child,
-    @required this.persistenceProvider,
-    Key key,
-  })  : assert(child != null),
-        assert(persistenceProvider != null),
-        super(key: key);
+    required this.child,
+    required this.persistenceProvider,
+    Key? key,
+  }) : super(key: key);
 
   /// Instantiates a new [FeatureDiscovery].
   ///
@@ -105,10 +103,10 @@ class FeatureDiscovery extends StatelessWidget {
   /// [sharedPreferencesPrefix] is used only if [recordStepsInSharedPreferences]
   /// is true.
   factory FeatureDiscovery({
-    @required Widget child,
+    required Widget child,
     bool recordStepsInSharedPreferences = true,
-    String sharedPreferencesPrefix,
-    Key key,
+    String? sharedPreferencesPrefix,
+    Key? key,
   }) =>
       FeatureDiscovery.withProvider(
         key: key,

--- a/lib/src/foundation/persistence_provider.dart
+++ b/lib/src/foundation/persistence_provider.dart
@@ -9,11 +9,11 @@ abstract class PersistenceProvider {
 
   /// Returns the list of steps (as strings) that the user has previously completed from
   /// the provided [featuresIds] set.
-  Future<Set<String>> completedSteps(Iterable<String> featuresIds);
+  Future<Set<String?>> completedSteps(Iterable<String?>? featuresIds);
 
   /// Informs the persistence layer that the user has completed the step identified by
   /// [featureId], and that it should record it in the persistence layer.
-  Future<void> completeStep(String featureId);
+  Future<void> completeStep(String? featureId);
 
   /// Requests that the persistence layer should remove the completion of the step
   /// identified by [featureId].
@@ -31,7 +31,7 @@ class SharedPreferencesProvider implements PersistenceProvider {
   /// If [sharedPrefsPrefix] is provided, it will be prepended to all step identifiers passed
   /// to the different methods. If [sharedPrefsPrefix] is not provided, the step
   /// identifiers will be used as-is.
-  const SharedPreferencesProvider([String sharedPrefsPrefix])
+  const SharedPreferencesProvider([String? sharedPrefsPrefix])
       : sharedPrefsPrefix = sharedPrefsPrefix ?? '';
 
   /// Use this string a prefix for all steps identifiers.
@@ -45,16 +45,16 @@ class SharedPreferencesProvider implements PersistenceProvider {
   }
 
   @override
-  Future<Set<String>> completedSteps(Iterable<String> featuresIds) async {
+  Future<Set<String?>> completedSteps(Iterable<String?>? featuresIds) async {
     final prefs = await SharedPreferences.getInstance();
-    return featuresIds
+    return featuresIds!
         .where((featureId) =>
             prefs.getBool(_normalizeFeatureId(featureId)) == true)
         .toSet();
   }
 
   @override
-  Future<void> completeStep(String featureId) async {
+  Future<void> completeStep(String? featureId) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_normalizeFeatureId(featureId), true);
   }
@@ -74,7 +74,7 @@ class SharedPreferencesProvider implements PersistenceProvider {
     await Future.wait(mapResult);
   }
 
-  String _normalizeFeatureId(String featureId) =>
+  String _normalizeFeatureId(String? featureId) =>
       '$sharedPrefsPrefix$featureId';
 }
 
@@ -86,26 +86,24 @@ class SharedPreferencesProvider implements PersistenceProvider {
 /// This is a great implementation for testing.
 class MemoryPersistenceProvider implements PersistenceProvider {
   /// Instantiates a new [MemoryPersistenceProvider] with an initial completed set of steps.
-  const MemoryPersistenceProvider(Set<String> steps)
-      : assert(steps != null),
-        _steps = steps;
+  const MemoryPersistenceProvider(Set<String?> steps) : _steps = steps;
 
   /// Instantiates an empty [MemoryPersistenceProvider] instance.
   factory MemoryPersistenceProvider.empty() =>
-      const MemoryPersistenceProvider(<String>{});
+      const MemoryPersistenceProvider(<String?>{});
 
-  final Set<String> _steps;
+  final Set<String?> _steps;
 
   @override
   Future<bool> hasCompletedStep(String featureId) async =>
       _steps.contains(featureId);
 
   @override
-  Future<Set<String>> completedSteps(Iterable<String> featuresIds) async =>
-      featuresIds.where((featureId) => _steps.contains(featureId)).toSet();
+  Future<Set<String?>> completedSteps(Iterable<String?>? featuresIds) async =>
+      featuresIds!.where((featureId) => _steps.contains(featureId)).toSet();
 
   @override
-  Future<void> completeStep(String featureId) async => _steps.add(featureId);
+  Future<void> completeStep(String? featureId) async => _steps.add(featureId);
 
   @override
   Future<void> clearStep(String featureId) async => _steps.remove(featureId);
@@ -125,11 +123,11 @@ class NoPersistenceProvider implements PersistenceProvider {
   Future<bool> hasCompletedStep(String featureId) async => false;
 
   @override
-  Future<Set<String>> completedSteps(Iterable<String> featuresIds) async =>
-      <String>{};
+  Future<Set<String?>> completedSteps(Iterable<String?>? featuresIds) async =>
+      <String?>{};
 
   @override
-  Future<void> completeStep(String featureId) async {
+  Future<void> completeStep(String? featureId) async {
     // NO-OP
   }
 

--- a/lib/src/rendering/custom_layout.dart
+++ b/lib/src/rendering/custom_layout.dart
@@ -1,8 +1,7 @@
 import 'dart:math';
-import 'package:flutter/animation.dart';
 
 import 'package:feature_discovery/src/widgets.dart';
-import 'package:flutter/foundation.dart';
+import 'package:flutter/animation.dart';
 import 'package:flutter/rendering.dart';
 
 enum BackgroundContentLayout {
@@ -37,23 +36,18 @@ class BackgroundContentLayoutDelegate extends MultiChildLayoutDelegate {
   final Offset anchor;
 
   final FeatureOverlayState state;
-  final double transitionProgress;
+  final double? transitionProgress;
 
   BackgroundContentLayoutDelegate({
-    @required this.overflowMode,
-    @required this.contentPosition,
-    @required this.backgroundCenter,
-    @required this.backgroundRadius,
-    @required this.anchor,
-    @required this.contentOffsetMultiplier,
-    @required this.state,
-    @required this.transitionProgress,
-  })  : assert(overflowMode != null),
-        assert(contentPosition != null),
-        assert(backgroundCenter != null),
-        assert(backgroundRadius != null),
-        assert(state != null),
-        assert(anchor != null);
+    required this.overflowMode,
+    required this.contentPosition,
+    required this.backgroundCenter,
+    required this.backgroundRadius,
+    required this.anchor,
+    required this.contentOffsetMultiplier,
+    required this.state,
+    required this.transitionProgress,
+  });
 
   @override
   void performLayout(Size size) {
@@ -126,13 +120,13 @@ class BackgroundContentLayoutDelegate extends MultiChildLayoutDelegate {
     switch (state) {
       case FeatureOverlayState.opening:
         matchedRadius *= const Interval(0, 0.8, curve: Curves.easeOut)
-            .transform(transitionProgress);
+            .transform(transitionProgress!);
         break;
       case FeatureOverlayState.completing:
-        matchedRadius += transitionProgress * 40;
+        matchedRadius += transitionProgress! * 40;
         break;
       case FeatureOverlayState.dismissing:
-        matchedRadius *= 1 - transitionProgress;
+        matchedRadius *= 1 - transitionProgress!;
         break;
       case FeatureOverlayState.opened:
         break;

--- a/lib/src/rendering/proxy_box.dart
+++ b/lib/src/rendering/proxy_box.dart
@@ -1,33 +1,30 @@
-import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 
 /// We use [RenderProxyBox] because we only want to clip and keep
 /// the properties of the _Content children.
 class RenderClipContent extends RenderProxyBox {
-  Offset _center;
-  double _radius;
+  Offset? _center;
+  double? _radius;
 
   RenderClipContent({
-    @required Offset center,
-    @required double radius,
-  })  : assert(center != null),
-        assert(radius != null),
-        _center = center,
+    required Offset center,
+    required double radius,
+  })   : _center = center,
         _radius = radius;
 
   /// The inner area of the DescribedFeatureOverlay.
   Path get innerCircle => Path()
     ..addOval(Rect.fromCircle(
-      center: globalToLocal(_center),
-      radius: _radius,
+      center: globalToLocal(_center!),
+      radius: _radius!,
     ));
 
-  set center(Offset center) {
+  set center(Offset? center) {
     _center = center;
     markNeedsPaint();
   }
 
-  set radius(double radius) {
+  set radius(double? radius) {
     _radius = radius;
     markNeedsPaint();
   }
@@ -37,7 +34,7 @@ class RenderClipContent extends RenderProxyBox {
   /// The reason this is necessary is that the content that might be overflowing will catch
   /// the hit events even when it is clipped out in paint.
   @override
-  bool hitTest(BoxHitTestResult result, {Offset position}) {
+  bool hitTest(BoxHitTestResult result, {required Offset position}) {
     // If the hit is inside of the inner area of the DescribedFeatureOverlay,
     // we want to catch the hit event and pass it to the children. Otherwise, we want to ignore it in order
     // to allow the GestureDetector in DescribedFeatureOverlay to catch it.

--- a/lib/src/widgets/content.dart
+++ b/lib/src/widgets/content.dart
@@ -8,10 +8,10 @@ class Content extends StatelessWidget {
   final double transitionProgress;
 
   /// Can be null.
-  final Widget title;
+  final Widget? title;
 
   /// Can be null.
-  final Widget description;
+  final Widget? description;
 
   final Color textColor;
 
@@ -22,21 +22,17 @@ class Content extends StatelessWidget {
   final double width;
 
   const Content({
-    Key key,
-    @required this.title,
-    @required this.description,
-    @required this.state,
-    @required this.transitionProgress,
-    @required this.textColor,
-    @required this.overflowMode,
-    @required this.backgroundRadius,
-    @required this.backgroundCenter,
-    @required this.width,
-  })  : assert(state != null),
-        assert(width != null),
-        assert(transitionProgress != null),
-        assert(textColor != null),
-        super(key: key);
+    Key? key,
+    required this.title,
+    required this.description,
+    required this.state,
+    required this.transitionProgress,
+    required this.textColor,
+    required this.overflowMode,
+    required this.backgroundRadius,
+    required this.backgroundCenter,
+    required this.width,
+  }) : super(key: key);
 
   double get opacity {
     switch (state) {
@@ -54,7 +50,6 @@ class Content extends StatelessWidget {
       case FeatureOverlayState.opened:
         return 1;
     }
-    throw ArgumentError.value(state);
   }
 
   @override
@@ -77,9 +72,9 @@ class Content extends StatelessWidget {
                   DefaultTextStyle(
                     style: Theme.of(context)
                         .textTheme
-                        .headline6
+                        .headline6!
                         .copyWith(color: textColor),
-                    child: title,
+                    child: title!,
                   ),
                 if (title != null && description != null)
                   const SizedBox(height: 8.0),
@@ -87,9 +82,9 @@ class Content extends StatelessWidget {
                   DefaultTextStyle(
                     style: Theme.of(context)
                         .textTheme
-                        .bodyText2
+                        .bodyText2!
                         .copyWith(color: textColor.withOpacity(0.9)),
-                    child: description,
+                    child: description!,
                   )
               ],
             ),
@@ -120,19 +115,19 @@ class Content extends StatelessWidget {
 // layout.
 // This is the reason why we need to clip in our custom RenderBox.
 class _ClipContent extends SingleChildRenderObjectWidget {
-  final double backgroundRadius;
-  final Offset backgroundCenter;
+  final double? backgroundRadius;
+  final Offset? backgroundCenter;
 
   const _ClipContent({
-    Key key,
-    Widget child,
+    Key? key,
+    Widget? child,
     this.backgroundCenter,
     this.backgroundRadius,
   }) : super(key: key, child: child);
 
   @override
   RenderObject createRenderObject(BuildContext context) =>
-      RenderClipContent(center: backgroundCenter, radius: backgroundRadius);
+      RenderClipContent(center: backgroundCenter!, radius: backgroundRadius!);
 
   @override
   void updateRenderObject(

--- a/lib/src/widgets/ensure_visible.dart
+++ b/lib/src/widgets/ensure_visible.dart
@@ -5,15 +5,13 @@ class EnsureVisible extends StatefulWidget {
   /// The child widget that we are wrapping
   final Widget child;
 
-  const EnsureVisible({Key key, @required this.child})
-      : assert(child != null),
-        super(key: key);
+  const EnsureVisible({Key? key, required this.child}) : super(key: key);
 
   @override
   EnsureVisibleState createState() => EnsureVisibleState();
 
   static void ensureVisible(BuildContext context) {
-    context.findAncestorStateOfType<EnsureVisibleState>().ensureVisible();
+    context.findAncestorStateOfType<EnsureVisibleState>()!.ensureVisible();
   }
 }
 
@@ -35,21 +33,17 @@ class EnsureVisibleState extends State<EnsureVisible> {
   Future<void> ensureVisible({
     Duration duration = const Duration(milliseconds: 100),
     Curve curve = Curves.ease,
-    double preciseAlignment,
+    double? preciseAlignment,
   }) async {
-    assert(duration != null, 'You need to specify a non-null duration.');
-    assert(curve != null, 'You need to specify a curve.');
     assert(
         preciseAlignment == null ||
             (preciseAlignment > 0 && preciseAlignment < 1),
         'The alignment needs to be null or between 0 and 1.');
 
     final renderObject = context.findRenderObject();
-    final viewport = RenderAbstractViewport.of(renderObject);
-    assert(viewport != null);
+    final viewport = RenderAbstractViewport.of(renderObject)!;
 
-    final scrollableState = Scrollable.of(context);
-    assert(scrollableState != null);
+    final scrollableState = Scrollable.of(context)!;
 
     final position = scrollableState.position;
     double alignment;
@@ -58,10 +52,10 @@ class EnsureVisibleState extends State<EnsureVisible> {
       alignment = preciseAlignment;
       // Only if the precise alignment exactly matches the current position no scrolling is necessary.
       if (position.pixels ==
-          viewport.getOffsetToReveal(renderObject, preciseAlignment).offset)
+          viewport.getOffsetToReveal(renderObject!, preciseAlignment).offset)
         return;
     } else if (position.pixels >
-        viewport.getOffsetToReveal(renderObject, 0).offset) {
+        viewport.getOffsetToReveal(renderObject!, 0).offset) {
       // Move down to the top of the viewport
       alignment = 0;
     } else if (position.pixels <

--- a/lib/src/widgets/layout.dart
+++ b/lib/src/widgets/layout.dart
@@ -1,15 +1,15 @@
 import 'package:flutter/material.dart';
 
 class CenterAbout extends StatelessWidget {
-  final Offset position;
-  final Widget child;
+  final Offset? position;
+  final Widget? child;
 
-  const CenterAbout({Key key, this.position, this.child}) : super(key: key);
+  const CenterAbout({Key? key, this.position, this.child}) : super(key: key);
 
   @override
   Widget build(BuildContext context) => Positioned(
-        top: position.dy,
-        left: position.dx,
+        top: position!.dy,
+        left: position!.dx,
         child: FractionalTranslation(
           translation: const Offset(-0.5, -0.5),
           child: child,
@@ -18,12 +18,12 @@ class CenterAbout extends StatelessWidget {
 }
 
 class AnchoredOverlay extends StatelessWidget {
-  final bool showOverlay;
-  final Widget Function(BuildContext, Offset anchor) overlayBuilder;
-  final Widget child;
+  final bool? showOverlay;
+  final Widget Function(BuildContext, Offset anchor)? overlayBuilder;
+  final Widget? child;
 
   const AnchoredOverlay(
-      {Key key, this.showOverlay, this.overlayBuilder, this.child})
+      {Key? key, this.showOverlay, this.overlayBuilder, this.child})
       : super(key: key);
 
   @override
@@ -36,7 +36,7 @@ class AnchoredOverlay extends StatelessWidget {
             final center = box.size.center(box.localToGlobal(
               const Offset(0.0, 0.0),
             ));
-            return overlayBuilder(context, center);
+            return overlayBuilder!(context, center);
           },
           child: child,
         ),
@@ -44,12 +44,12 @@ class AnchoredOverlay extends StatelessWidget {
 }
 
 class OverlayBuilder extends StatefulWidget {
-  final bool showOverlay;
-  final Function(BuildContext context) overlayBuilder;
-  final Widget child;
+  final bool? showOverlay;
+  final Function(BuildContext context)? overlayBuilder;
+  final Widget? child;
 
   const OverlayBuilder(
-      {Key key, this.showOverlay = false, this.overlayBuilder, this.child})
+      {Key? key, this.showOverlay = false, this.overlayBuilder, this.child})
       : super(key: key);
 
   @override
@@ -57,12 +57,12 @@ class OverlayBuilder extends StatefulWidget {
 }
 
 class _OverlayBuilderState extends State<OverlayBuilder> {
-  OverlayEntry overlayEntry;
+  OverlayEntry? overlayEntry;
 
   @override
   void initState() {
     super.initState();
-    if (widget.showOverlay) showOverlay();
+    if (widget.showOverlay!) showOverlay();
   }
 
   @override
@@ -87,31 +87,31 @@ class _OverlayBuilderState extends State<OverlayBuilder> {
 
   void showOverlay() {
     overlayEntry = OverlayEntry(
-      builder: widget.overlayBuilder,
+      builder: widget.overlayBuilder as Widget Function(BuildContext),
     );
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      Overlay.of(context).insert(overlayEntry);
+    WidgetsBinding.instance!.addPostFrameCallback((_) {
+      Overlay.of(context)!.insert(overlayEntry!);
     });
   }
 
   void hideOverlay() {
-    overlayEntry.remove();
+    overlayEntry!.remove();
     overlayEntry = null;
   }
 
   void syncWidgetAndOverlay() {
-    if (isShowingOverlay() && !widget.showOverlay) {
+    if (isShowingOverlay() && !widget.showOverlay!) {
       hideOverlay();
-    } else if (!isShowingOverlay() && widget.showOverlay) showOverlay();
+    } else if (!isShowingOverlay() && widget.showOverlay!) showOverlay();
   }
 
   void buildOverlay() async => overlayEntry?.markNeedsBuild();
 
   @override
   Widget build(BuildContext context) {
-    WidgetsBinding.instance.addPostFrameCallback((_) {
+    WidgetsBinding.instance!.addPostFrameCallback((_) {
       buildOverlay();
     });
-    return widget.child;
+    return widget.child!;
   }
 }

--- a/lib/src/widgets/overlay.dart
+++ b/lib/src/widgets/overlay.dart
@@ -28,7 +28,7 @@ class DescribedFeatureOverlay extends StatefulWidget {
 
   /// The color of the large circle, where the text sits on.
   /// If null, defaults to [ThemeData.primaryColor].
-  final Color backgroundColor;
+  final Color? backgroundColor;
 
   /// The opacity of the large circle, where the text sits on.
   /// If null, defaults to 0.96.
@@ -46,7 +46,7 @@ class DescribedFeatureOverlay extends StatefulWidget {
   /// any [Widget].
   /// The overlay uses a [DefaultTextStyle] for the title, which is a combination
   /// of [TextTheme.headline6] from [Theme] and the [textColor].
-  final Widget title;
+  final Widget? title;
 
   /// This is the second content widget, i.e. it is displayed below [description].
   ///
@@ -54,7 +54,7 @@ class DescribedFeatureOverlay extends StatefulWidget {
   /// any [Widget].
   /// The overlay uses a [DefaultTextStyle] for the description, which is a combination
   /// of [TextTheme.bodyText2] from [Theme] and the [textColor].
-  final Widget description;
+  final Widget? description;
 
   /// This is usually an [Icon].
   /// The final tap target will already have a tap listener to finish each step.
@@ -76,7 +76,7 @@ class DescribedFeatureOverlay extends StatefulWidget {
   /// In this case, we try to open the next step.
   ///
   /// When the [Future] finishes and evaluates to `true`, this step will be shown.
-  final Future<bool> Function() onOpen;
+  final Future<bool> Function()? onOpen;
 
   /// Called whenever the user taps outside the overlay area.
   /// This function needs to return a [bool], either from an `async` scope
@@ -84,13 +84,13 @@ class DescribedFeatureOverlay extends StatefulWidget {
   ///
   /// If the function returns `false`, nothing happens. If it returns `true`,
   /// all of the current steps are dismissed.
-  final Future<bool> Function() onDismiss;
+  final Future<bool> Function()? onDismiss;
 
   /// Called when the tap target is tapped.
   /// Whenever the [Future] this function returns finishes with `true`, the feature discovery
   /// will continue and the next step will try to open after a closing animation.
   /// If it completes with `false`, nothing happens.
-  final Future<bool> Function() onComplete;
+  final Future<bool> Function()? onComplete;
 
   /// Controls what happens with content that overflows the background's area.
   ///
@@ -135,18 +135,18 @@ class DescribedFeatureOverlay extends StatefulWidget {
   ///
   /// If the function returns `false`, nothing happens. If it returns `true`,
   /// all of the current steps are dismissed.
-  final Future<bool> Function() onBackgroundTap;
+  final Future<bool> Function()? onBackgroundTap;
 
   const DescribedFeatureOverlay({
-    Key key,
-    @required this.featureId,
-    @required this.tapTarget,
+    Key? key,
+    required this.featureId,
+    required this.tapTarget,
     this.backgroundColor,
     this.targetColor = Colors.white,
     this.textColor = Colors.white,
     this.title,
     this.description,
-    @required this.child,
+    required this.child,
     this.onOpen,
     this.onComplete,
     this.onDismiss,
@@ -162,21 +162,7 @@ class DescribedFeatureOverlay extends StatefulWidget {
     this.barrierDismissible = true,
     this.backgroundDismissible = false,
     this.onBackgroundTap,
-  })  : assert(featureId != null),
-        assert(tapTarget != null),
-        assert(child != null),
-        assert(contentLocation != null),
-        assert(enablePulsingAnimation != null),
-        assert(targetColor != null),
-        assert(textColor != null),
-        assert(overflowMode != null),
-        assert(openDuration != null),
-        assert(pulseDuration != null),
-        assert(completeDuration != null),
-        assert(dismissDuration != null),
-        assert(barrierDismissible != null),
-        assert(backgroundDismissible != null),
-        assert(
+  })  : assert(
           barrierDismissible == true || onDismiss == null,
           'Cannot provide both a barrierDismissible and onDismiss function\n'
           'The onDismiss function will never get executed when barrierDismissible is set to false.',
@@ -190,31 +176,31 @@ class DescribedFeatureOverlay extends StatefulWidget {
 
 class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
     with TickerProviderStateMixin {
-  Size _screenSize;
+  late Size _screenSize;
 
-  FeatureOverlayState _state;
+  FeatureOverlayState? _state;
 
-  double _transitionProgress;
+  double? _transitionProgress;
 
-  AnimationController _openController;
+  late AnimationController _openController;
 
   /// The usual order is open, complete, then dismiss across the project,
   /// but pulse does not exist for most other occurrences.
-  AnimationController _pulseController;
-  AnimationController _completeController;
-  AnimationController _dismissController;
+  late AnimationController _pulseController;
+  late AnimationController _completeController;
+  late AnimationController _dismissController;
 
   /// The local reference to the [Bloc] is needed because it is used in [dispose].
-  Bloc _bloc;
+  late Bloc _bloc;
 
-  Stream<EventType> _eventsStream;
-  StreamSubscription<EventType> _eventsSubscription;
+  Stream<EventType>? _eventsStream;
+  StreamSubscription<EventType>? _eventsSubscription;
 
   /// If either [_complete] or [_dismiss] were called previously,
   /// the overlay is awaiting the closure of itself. This is necessary
   /// because [DescribedFeatureOverlay.onComplete] and [DescribedFeatureOverlay.onDismiss]
   /// are `async` and while those are evaluated, the methods should not execute again.
-  bool _awaitingClosure;
+  late bool _awaitingClosure;
 
   @override
   void initState() {
@@ -272,7 +258,7 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
     _completeController.dispose();
     _dismissController.dispose();
 
-    _eventsSubscription.cancel();
+    _eventsSubscription!.cancel();
 
     // If this widget is disposed while still showing an overlay,
     // it needs to remove itself from the active overlays.
@@ -298,9 +284,7 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
   void _setStream(Stream<EventType> newStream) {
     _eventsSubscription?.cancel();
     _eventsStream = newStream;
-    _eventsSubscription = _eventsStream.listen((EventType event) async {
-      assert(event != null);
-
+    _eventsSubscription = _eventsStream!.listen((EventType event) async {
       switch (event) {
         case EventType.open:
           // Only try opening when the active feature id matches the id of this widget.
@@ -355,9 +339,7 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
     _bloc.activeOverlays++;
 
     if (widget.onOpen != null) {
-      final shouldOpen = await widget.onOpen();
-      assert(shouldOpen != null,
-          'You need to return a [Future] that completes with true or false in [onOpen].');
+      final shouldOpen = await widget.onOpen!();
       if (!shouldOpen) {
         await FeatureDiscovery.completeCurrentStep(context);
         return;
@@ -404,8 +386,6 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
         _awaitingClosure = false;
       }
 
-      assert(shouldMoveOn != null,
-          'You need to return a [Future] that completes with true or false in ${isComplete ? '[onComplete]' : '[onDismiss]'}.');
       if (!shouldMoveOn) return;
       _awaitingClosure = true;
     }
@@ -432,7 +412,7 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
         : FeatureOverlayState.dismissing;
 
     final from = !isComplete && previousState == FeatureOverlayState.opening
-        ? 1 - _transitionProgress
+        ? 1 - _transitionProgress!
         : 0;
     final controller = isComplete ? _completeController : _dismissController;
     await controller.forward(from: from.toDouble());
@@ -471,7 +451,7 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
     return backgroundRadius;
   }
 
-  Offset _backgroundPosition(Offset anchor, ContentLocation contentLocation) {
+  Offset? _backgroundPosition(Offset anchor, ContentLocation contentLocation) {
     final width = min(_screenSize.width, _screenSize.height);
     final isBackgroundCentered = _isCloseToTopOrBottom(anchor);
 
@@ -480,7 +460,7 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
     } else {
       final startingBackgroundPosition = anchor;
 
-      Offset endingBackgroundPosition;
+      Offset? endingBackgroundPosition;
       switch (contentLocation) {
         case ContentLocation.above:
           endingBackgroundPosition = Offset(
@@ -504,20 +484,21 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
         case FeatureOverlayState.opening:
           final adjustedPercent =
               const Interval(0.0, 0.8, curve: Curves.easeOut)
-                  .transform(_transitionProgress);
+                  .transform(_transitionProgress!);
           return Offset.lerp(startingBackgroundPosition,
               endingBackgroundPosition, adjustedPercent);
         case FeatureOverlayState.completing:
           return endingBackgroundPosition;
         case FeatureOverlayState.dismissing:
           return Offset.lerp(endingBackgroundPosition,
-              startingBackgroundPosition, _transitionProgress);
+              startingBackgroundPosition, _transitionProgress!);
         case FeatureOverlayState.opened:
           return endingBackgroundPosition;
         case FeatureOverlayState.closed:
           return startingBackgroundPosition;
+        case null:
+          return throw ArgumentError.notNull();
       }
-      throw ArgumentError.value(_state);
     }
   }
 
@@ -538,7 +519,7 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
     }
   }
 
-  Offset _contentCenterPosition(Offset anchor) {
+  Offset? _contentCenterPosition(Offset anchor) {
     final width = min(_screenSize.width, _screenSize.height);
     final isBackgroundCentered = _isCloseToTopOrBottom(anchor);
 
@@ -557,20 +538,21 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
         case FeatureOverlayState.opening:
           final adjustedPercent =
               const Interval(0.0, 0.8, curve: Curves.easeOut)
-                  .transform(_transitionProgress);
+                  .transform(_transitionProgress!);
           return Offset.lerp(startingBackgroundPosition,
               endingBackgroundPosition, adjustedPercent);
         case FeatureOverlayState.completing:
           return endingBackgroundPosition;
         case FeatureOverlayState.dismissing:
           return Offset.lerp(endingBackgroundPosition,
-              startingBackgroundPosition, _transitionProgress);
+              startingBackgroundPosition, _transitionProgress!);
         case FeatureOverlayState.opened:
           return endingBackgroundPosition;
         case FeatureOverlayState.closed:
           return startingBackgroundPosition;
+        case null:
+          throw ArgumentError.notNull();
       }
-      throw ArgumentError.value(_state);
     }
   }
 
@@ -588,11 +570,11 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
     final contentLocation = _nonTrivialContentOrientation(anchor);
     assert(contentLocation != ContentLocation.trivial);
 
-    final backgroundCenter = _backgroundPosition(anchor, contentLocation);
+    final backgroundCenter = _backgroundPosition(anchor, contentLocation)!;
     final backgroundRadius = _backgroundRadius(anchor);
 
     final contentOffsetMultiplier = _contentOffsetMultiplier(contentLocation);
-    final contentCenterPosition = _contentCenterPosition(anchor);
+    final contentCenterPosition = _contentCenterPosition(anchor)!;
 
     final contentWidth = min(_screenSize.width, _screenSize.height);
 
@@ -649,17 +631,17 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
             backgroundRadius: backgroundRadius,
             anchor: anchor,
             contentOffsetMultiplier: contentOffsetMultiplier,
-            state: _state,
+            state: _state!,
             transitionProgress: _transitionProgress,
           ),
           children: <Widget>[
             LayoutId(
               id: BackgroundContentLayout.background,
               child: _Background(
-                transitionProgress: _transitionProgress,
+                transitionProgress: _transitionProgress!,
                 color: widget.backgroundColor ?? Theme.of(context).primaryColor,
                 defaultOpacity: widget.backgroundOpacity,
-                state: _state,
+                state: _state!,
                 overflowMode: widget.overflowMode,
                 tryDismissThisThenAll: tryDismissThisThenAll,
                 backgroundDismissible: widget.backgroundDismissible,
@@ -669,8 +651,8 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
             LayoutId(
               id: BackgroundContentLayout.content,
               child: Content(
-                state: _state,
-                transitionProgress: _transitionProgress,
+                state: _state!,
+                transitionProgress: _transitionProgress!,
                 title: widget.title,
                 description: widget.description,
                 textColor: widget.textColor,
@@ -683,14 +665,14 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
           ],
         ),
         _Pulse(
-          state: _state,
-          transitionProgress: _transitionProgress,
+          state: _state!,
+          transitionProgress: _transitionProgress!,
           anchor: anchor,
           color: widget.targetColor,
         ),
         _TapTarget(
-          state: _state,
-          transitionProgress: _transitionProgress,
+          state: _state!,
+          transitionProgress: _transitionProgress!,
           anchor: anchor,
           color: widget.targetColor,
           onPressed: tryCompleteThis,
@@ -717,23 +699,19 @@ class _Background extends StatelessWidget {
   final double defaultOpacity;
   final VoidCallback tryDismissThisThenAll;
   final bool backgroundDismissible;
-  final Future<bool> Function() onBackgroundTap;
+  final Future<bool> Function()? onBackgroundTap;
 
   const _Background({
-    Key key,
-    @required this.color,
-    @required this.state,
-    @required this.transitionProgress,
-    @required this.overflowMode,
-    @required this.defaultOpacity,
-    @required this.tryDismissThisThenAll,
-    @required this.backgroundDismissible,
-    @required this.onBackgroundTap,
-  })  : assert(color != null),
-        assert(state != null),
-        assert(transitionProgress != null),
-        assert(tryDismissThisThenAll != null),
-        super(key: key);
+    Key? key,
+    required this.color,
+    required this.state,
+    required this.transitionProgress,
+    required this.overflowMode,
+    required this.defaultOpacity,
+    required this.tryDismissThisThenAll,
+    required this.backgroundDismissible,
+    required this.onBackgroundTap,
+  }) : super(key: key);
 
   double get opacity {
     switch (state) {
@@ -756,7 +734,6 @@ class _Background extends StatelessWidget {
       case FeatureOverlayState.closed:
         return 0;
     }
-    throw ArgumentError.value(state);
   }
 
   @override
@@ -777,21 +754,21 @@ class _Background extends StatelessWidget {
 
     result = GestureDetector(
       onTap: () {
-        if (backgroundDismissible && tryDismissThisThenAll != null) {
+        if (backgroundDismissible) {
           tryDismissThisThenAll();
         }
 
         if (onBackgroundTap != null) {
-          onBackgroundTap();
+          onBackgroundTap!();
         }
       },
       onPanUpdate: (_) {
-        if (backgroundDismissible && tryDismissThisThenAll != null) {
+        if (backgroundDismissible) {
           tryDismissThisThenAll();
         }
 
         if (onBackgroundTap != null) {
-          onBackgroundTap();
+          onBackgroundTap!();
         }
       },
       child: result,
@@ -808,16 +785,12 @@ class _Pulse extends StatelessWidget {
   final Color color;
 
   const _Pulse({
-    Key key,
-    @required this.state,
-    @required this.transitionProgress,
-    @required this.anchor,
-    @required this.color,
-  })  : assert(state != null),
-        assert(transitionProgress != null),
-        assert(anchor != null),
-        assert(color != null),
-        super(key: key);
+    Key? key,
+    required this.state,
+    required this.transitionProgress,
+    required this.anchor,
+    required this.color,
+  }) : super(key: key);
 
   double get radius {
     switch (state) {
@@ -836,7 +809,6 @@ class _Pulse extends StatelessWidget {
       case FeatureOverlayState.closed:
         return 0;
     }
-    throw ArgumentError.value(state);
   }
 
   double get opacity {
@@ -852,7 +824,6 @@ class _Pulse extends StatelessWidget {
       case FeatureOverlayState.closed:
         return 0;
     }
-    throw ArgumentError.value(state);
   }
 
   @override
@@ -880,19 +851,14 @@ class _TapTarget extends StatelessWidget {
   final VoidCallback onPressed;
 
   const _TapTarget({
-    Key key,
-    @required this.anchor,
-    @required this.child,
-    @required this.onPressed,
-    @required this.color,
-    @required this.state,
-    @required this.transitionProgress,
-  })  : assert(anchor != null),
-        assert(child != null),
-        assert(state != null),
-        assert(transitionProgress != null),
-        assert(color != null),
-        super(key: key);
+    Key? key,
+    required this.anchor,
+    required this.child,
+    required this.onPressed,
+    required this.color,
+    required this.state,
+    required this.transitionProgress,
+  }) : super(key: key);
 
   double get opacity {
     switch (state) {
@@ -909,7 +875,6 @@ class _TapTarget extends StatelessWidget {
       case FeatureOverlayState.opened:
         return 1;
     }
-    throw ArgumentError.value(state);
   }
 
   double get radius {
@@ -932,7 +897,6 @@ class _TapTarget extends StatelessWidget {
       case FeatureOverlayState.dismissing:
         return 20 + 24 * (1 - transitionProgress);
     }
-    throw ArgumentError.value(state);
   }
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A Flutter package that implements Material Design Feature discovery
   to show a description of specific features to new users.
   See https://tinyurl.com/FeatureDiscovery
-version: 0.13.0+1
+version: 0.14.0
 homepage: https://github.com/ayalma/feature_discovery
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,14 +9,14 @@ homepage: https://github.com/ayalma/feature_discovery
 environment:
   # This should match the Flutter stable SDK constraint.
   # See https://github.com/flutter/flutter/blob/stable/packages/flutter/pubspec.yaml.
-  sdk: ">=2.2.2 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:
     sdk: flutter
 
-  provider: ^4.0.4
-  shared_preferences: ^0.5.6+1
+  provider: ^5.0.0
+  shared_preferences: ^2.0.3
 
 dev_dependencies:
   flutter_test:

--- a/test/feature_discovery_test.dart
+++ b/test/feature_discovery_test.dart
@@ -5,12 +5,8 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'widgets.dart';
 
-List<String> textsToMatch(List<String> featureIds) {
-  assert(featureIds != null);
-  return featureIds
-      .map((featureId) => 'Test has passed for $featureId')
-      .toList();
-}
+List<String> textsToMatch(List<String> featureIds) =>
+    featureIds.map((featureId) => 'Test has passed for $featureId').toList();
 
 void main() {
   group('Basic behavior', () {
@@ -192,7 +188,7 @@ void main() {
 
     for (final modeEntry in modes.entries) {
       testWidgets(modeEntry.key.toString(), (WidgetTester tester) async {
-        BuildContext context;
+        late BuildContext context;
 
         var triggered = false;
 

--- a/test/widgets.dart
+++ b/test/widgets.dart
@@ -6,10 +6,10 @@ import 'package:flutter/material.dart';
 @visibleForTesting
 class TestWrapper extends StatelessWidget {
   /// This will be passed to [Scaffold.body].
-  final Widget child;
+  final Widget? child;
 
   const TestWrapper({
-    Key key,
+    Key? key,
     this.child,
   }) : super(key: key);
 
@@ -34,8 +34,8 @@ class TestWidget extends StatelessWidget {
   final bool allowShowingDuplicate;
 
   const TestWidget({
-    Key key,
-    @required this.featureIds,
+    Key? key,
+    required this.featureIds,
     this.allowShowingDuplicate = false,
   }) : super(key: key);
 
@@ -60,9 +60,9 @@ class TestIcon extends StatefulWidget {
   final bool allowShowingDuplicate;
 
   const TestIcon({
-    Key key,
-    @required this.featureId,
-    @required this.allowShowingDuplicate,
+    Key? key,
+    required this.featureId,
+    required this.allowShowingDuplicate,
   }) : super(key: key);
 
   @override
@@ -96,16 +96,16 @@ class TestIconState extends State<TestIcon> {
 /// This works properly using [TestWidgetsFlutterBinding.setSurfaceSize] with `Size(3e2, 4e3)`.
 @visibleForTesting
 class OverflowingDescriptionFeature extends StatelessWidget {
-  final String featureId;
-  final IconData icon;
+  final String? featureId;
+  final IconData? icon;
 
-  final void Function(BuildContext context) onContext;
-  final void Function() onDismiss;
+  final void Function(BuildContext context)? onContext;
+  final void Function()? onDismiss;
 
-  final OverflowMode mode;
+  final OverflowMode? mode;
 
   const OverflowingDescriptionFeature({
-    Key key,
+    Key? key,
     this.onContext,
     this.featureId,
     this.icon,
@@ -117,14 +117,14 @@ class OverflowingDescriptionFeature extends StatelessWidget {
   Widget build(_) => TestWrapper(
         child: Builder(
           builder: (context) {
-            onContext(context);
+            onContext!(context);
 
             return Stack(
               children: <Widget>[
                 Align(
                   alignment: Alignment.topCenter,
                   child: DescribedFeatureOverlay(
-                    featureId: featureId,
+                    featureId: featureId!,
                     tapTarget: const Icon(Icons.arrow_drop_down_circle),
                     description: Container(
                       width: double.infinity,
@@ -133,7 +133,7 @@ class OverflowingDescriptionFeature extends StatelessWidget {
                     ),
                     contentLocation: ContentLocation.below,
                     enablePulsingAnimation: false,
-                    overflowMode: mode,
+                    overflowMode: mode!,
                     onDismiss: () async {
                       onDismiss?.call();
                       return true;
@@ -170,11 +170,11 @@ class WidgetWithDisposableFeature extends StatefulWidget {
   final String staticFeatureTitle, disposableFeatureTitle;
 
   const WidgetWithDisposableFeature({
-    Key key,
-    @required this.featureId,
-    @required this.featureIcon,
-    @required this.staticFeatureTitle,
-    @required this.disposableFeatureTitle,
+    Key? key,
+    required this.featureId,
+    required this.featureIcon,
+    required this.staticFeatureTitle,
+    required this.disposableFeatureTitle,
   }) : super(key: key);
 
   @override
@@ -184,7 +184,7 @@ class WidgetWithDisposableFeature extends StatefulWidget {
 @visibleForTesting
 class WidgetWithDisposableFeatureState
     extends State<WidgetWithDisposableFeature> {
-  bool _showDisposableFeature;
+  late bool _showDisposableFeature;
 
   @override
   void initState() {


### PR DESCRIPTION
## Description
I propose this pull request to [migrate this plugin to null safety](https://dart.dev/null-safety/migration-guide) as it is the way to go now that Flutter 2 has been released.

Here are the changes I introduced:
* Update SDK dependency version to 2.12.0+
* Run `dart migrate` on existing code to remove unsafe nulls (for the package & example)
* Changed `FlatButton` to `TextButton` and `RaisedButton` to `ElevationButton`
* Add a new version (`0.14.0`) to the changelog

Please check everything twice!

## Testing
- [x] All existing Tests are passing
- [x] Tested it manually on a Android emulator 

Demo:

https://user-images.githubusercontent.com/24459435/110187638-50370f80-7e19-11eb-9b44-e916ab27236c.mov

### Related tickets
Closes #67 