### PR TITLE
Discovery aligned right fix

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -24,7 +24,7 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.2
+  cupertino_icons: ^1.0.3
   feature_discovery:
     path: ../
 

--- a/lib/src/foundation/feature_discovery.dart
+++ b/lib/src/foundation/feature_discovery.dart
@@ -15,6 +15,7 @@ enum ContentLocation {
   above,
   below,
   trivial,
+  right,
 }
 
 class FeatureDiscovery extends StatelessWidget {

--- a/lib/src/widgets/overlay.dart
+++ b/lib/src/widgets/overlay.dart
@@ -462,6 +462,10 @@ class _DescribedFeatureOverlayState extends State<DescribedFeatureOverlay>
 
       Offset? endingBackgroundPosition;
       switch (contentLocation) {
+        case ContentLocation.right:
+          endingBackgroundPosition =
+              Offset(width / 2.0, anchor.dy + (width / 4.0));
+          break;
         case ContentLocation.above:
           endingBackgroundPosition = Offset(
               anchor.dx -

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   A Flutter package that implements Material Design Feature discovery
   to show a description of specific features to new users.
   See https://tinyurl.com/FeatureDiscovery
-version: 0.14.0
+version: 0.14.0+1
 homepage: https://github.com/ayalma/feature_discovery
 
 environment:
@@ -16,14 +16,11 @@ dependencies:
     sdk: flutter
 
   provider: ^5.0.0
-  shared_preferences: ^2.0.3
+  shared_preferences: ^2.0.5
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  pedantic: 1.9.0
+  pedantic: ^1.11.0
 
-dependency_overrides:
-  # TODO(creativecreatorormaybenot): Remove when Pedantic is updated in flutter_test.
-  pedantic: 1.9.0


### PR DESCRIPTION
fixes an issue that occurs when the feature discovery is called with a
widget that is aligned to the right of the screen

fixes #62